### PR TITLE
Docs and opensource setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report something that isn't working
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See the problem
+
+## Expected behavior
+
+What you expected to happen.
+
+## Context
+
+- Page / site where it happens:
+- Chrome version:
+- Extension version (from the popup):
+
+## Screenshots / console output
+
+If applicable, add screenshots or relevant console errors.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What problem would this solve? What's the use case?
+
+## Proposed solution
+
+What you'd like to see happen.
+
+## Alternatives
+
+Any alternative approaches you've considered.
+
+## Additional context
+
+Anything else worth mentioning.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Type of change
+
+- [ ] Bug fix (PATCH)
+- [ ] New feature / behavior change (MINOR)
+- [ ] Refactor / chore
+- [ ] Docs
+
+## Checklist
+
+- [ ] `npm run build` passes
+- [ ] `npm run typecheck` passes
+- [ ] Tested as an unpacked extension in Chrome
+- [ ] If the version was bumped, `manifest.json` and `package.json` match

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Reckue Languages
+
+Thanks for your interest in contributing. This guide covers the local setup and the conventions we follow.
+
+## Getting started
+
+```sh
+npm install      # install dependencies
+npm run build    # build the extension bundles into dist/
+npm run typecheck # type-check without emitting
+```
+
+Load the unpacked extension from the project root (the folder with `manifest.json`) via `chrome://extensions/` → **Developer mode** → **Load unpacked**. See the [README](README.md#build--install-development) for the full walkthrough.
+
+## Project layout
+
+Two independent surfaces, built as separate bundles:
+
+- **Content script** — `src/page/*` → `dist/page/page.js`. Vanilla TypeScript, direct DOM work, highlighting via the CSS Custom Highlight API. **No React/Preact here.**
+- **Popup** — `src/popup/ui/*` → `dist/popup/popup.js`. Preact.
+
+The shared data layer (`src/core/words/*`) is plain TypeScript and is used by both — keep it framework-free.
+
+## Branches
+
+Branches follow the pattern `version/<x.y.z>_<slug>`, where the slug names the feature or area of work — e.g. `version/0.6.7_shadow_dom`. Several features may run in parallel under nearby versions.
+
+## Commits
+
+- Keep messages short and to the point.
+- Prefix with the version when relevant: `[version X.Y.Z] <description>`.
+- Bump the version in its own commit.
+
+We follow [SemVer](https://semver.org/) on the `0.x` track until 1.0:
+
+- **PATCH** (`0.x.N`) — bug fixes and small UI tweaks.
+- **MINOR** (`0.N.0`) — new features and notable behavior changes.
+
+When bumping the version, update **both** `manifest.json` and `package.json` to the same value in the same commit — the runtime reads the version from `manifest.json`.
+
+## Pull requests
+
+- Integration happens through pull requests into `master`. Direct pushes to `master` are not accepted.
+- Before opening a PR, make sure `npm run build` and `npm run typecheck` both pass. CI runs these on every PR.
+- Keep PRs focused; describe what changed and why.
+
+## Reporting bugs and requesting features
+
+Use the [issue tracker](https://github.com/Reckue/reckue-langs/issues). For bugs, include steps to reproduce, the page or context where it happens, and your browser version.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Reckue
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,96 +1,70 @@
-# Reckue Langs - Chrome Extinction
-## Vacabulary Assistant – Learn New Words as You Browse
+# Reckue Languages
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)  
-[![Version](https://img.shields.io/github/package-json/v/Reckue/reckue-langs)](https://github.com/Reckue/reckue-langs) 
-[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)  
+> An interactive vocabulary builder for Chrome — click words on any page to save, highlight, and turn them into flashcards.
+
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Version](https://img.shields.io/github/package-json/v/Reckue/reckue-langs)](https://github.com/Reckue/reckue-langs)
+[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Issues](https://img.shields.io/github/issues/Reckue/reckue-langs)](https://github.com/Reckue/reckue-langs/issues)
 
-## What is Vacabulary Assistant?
-Vacabulary Assistant is an **interactive vocabulary builder** that helps you collect and organize new words effortlessly while browsing the web. With just a click, you can **save words**, **highlight them**, and **track your learning progress** directly in your browser. Marked words take on customizable colors and transform into interactive vocabulary cards.
+## What it does
 
-### How It Works
-Forget about manually creating vocabulary cards—**Vacabulary Assistant does it for you!** Just browse the web as usual, reading articles, books, or any content. Whenever you come across a word you want to remember, **click on it** to add it to your personal wordbook.
+Reckue Languages is a Chrome extension (Manifest V3) that builds your vocabulary as you read. Browse the web normally; when you hit a word worth remembering, click it. The word is saved to your personal wordbook, highlighted on the page, and available as a flashcard in the popup.
 
-As you continue learning, you can **track your progress**, **improve retention**, and **level up your vocabulary effortlessly**. Vacabulary Assistant streamlines language learning, making it seamless and automatic, so you can focus on mastering new words efficiently.
+Saved words stay highlighted across pages, so you keep seeing them in context — which is what makes them stick.
 
-🚀 **Key Features:**  
-✔️ Save words instantly from any webpage  
-✔️ Highlight words in custom colors  
-✔️ Automatically turn words into vocabulary cards  
-✔️ Track progress and enhance retention  
+## Features
 
-🔧 **Installation & Usage**  
-Get started in minutes! Follow the [Build Guide](#build-guide) to install and set up the extension.
+- Save words with a single click on any page
+- Per-level highlighting via the CSS Custom Highlight API (the page's own DOM is left untouched)
+- A popup wordbook to review and manage what you've collected
+- Works inside iframes and shadow DOM
 
-<div style="border: 1px #1e81c6 solid; border-radius: 10px; background: #acd1ff">
+![Extension in action](img_2.png)
 
-![img_2.png](img_2.png)
+## Build & install (development)
 
-</div>
+The extension is built from TypeScript with Webpack. To run it locally as an unpacked extension:
 
-## 🛠 Build & Installation Guide
+**1. Install dependencies**
 
-Follow these simple steps to set up **Vacabulary Assistant** in your browser. No prior experience required! 🚀
-
-### **1️⃣ Install Dependencies**
-Open a terminal and run the following command to install all required dependencies:
-```sh  
-npm install  
+```sh
+npm install
 ```
 
-### **2️⃣ Build the Extension**
-Compile the project by running:
-```sh  
-npm run build  
+**2. Build the bundles**
+
+```sh
+npm run build
 ```
-This will generate the necessary files:
-- `page/page.ts`
-- `popup/popup.ts`
 
-### **3️⃣ Enable Developer Mode in Chrome**
-1. Open Google Chrome and navigate to:  
-   🔗 `chrome://extensions/`
-2. Toggle the **Developer mode** switch (usually in the top-right corner).
+This compiles the source in `src/` into the loadable bundles:
 
-### **4️⃣ Load the Unpacked Extension**
-1. Click **"Load unpacked"**.
-2. Select the folder where your `manifest.json` file is located.
+- `dist/page/page.js` — content script
+- `dist/popup/popup.js` — popup UI
 
-![img_1.png](img_1.png)
+**3. Load it into Chrome**
 
-### **5️⃣ Test the Extension**
-- Open any webpage and try selecting a word.
-- You should see an option to save it to your vocabulary list.
-- Open the extension popup to view and manage your saved words.
+1. Open `chrome://extensions/`.
+2. Enable **Developer mode** (top-right toggle).
+3. Click **Load unpacked** and select this project's root folder (the one containing `manifest.json`).
 
-### **6️⃣ You're All Set! 🎉**
-Your **Vacabulary Assistant** extension is now installed and ready to help you expand your vocabulary! If you encounter any issues, check the [GitHub Issues](https://github.com/Reckue/reckue-langs/issues) page or contribute improvements.
+![Load unpacked](img_1.png)
 
-## Updates History:
+**4. Try it**
 
-#### ~0.1.5-0.1.6 - Preview
-![](https://sun9-31.userapi.com/rIXe5gjImJUmVA2AIUShndTDDTXp_5mojL55Vg/5XZGeZK_Uso.jpg)
+Open any web page and click a word — it should be saved and highlighted. Open the extension popup to review your wordbook.
 
-#### 0.2.0 - First working prototype
-- Redesigned popup menu (preparing for collections)
-- Optimized parsing speed (2x faster)
-- Added instant word-saving button on Google Translate
-- Fixed various bugs
+## Tech stack
 
-#### 0.2.7 - Development resumed
-- Added documentation, comments, and TODOs
-- Moved `start.js` from `./parser` to `./scripts`
+- **TypeScript** (`target: es2022`), bundled with **Webpack 5** + `ts-loader`
+- **Content script** (`src/page/*`) — vanilla TypeScript, direct DOM work, highlighting via the CSS Custom Highlight API
+- **Popup** (`src/popup/ui/*`) — [Preact](https://preactjs.com/)
 
-#### 0.3.0 - Improved parser and form builder
-- Enhanced text parsing and page building
-- Increased algorithm efficiency
-- Implemented mock wordbook and `mocks.js`
+## Contributing
 
-#### 0.3.6 - Migration to OOP
-- Refactored files into classes
-- Added interactive popup words feature
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, branch and commit conventions, and how to open a pull request. Found a bug or have an idea? [Open an issue](https://github.com/Reckue/reckue-langs/issues).
 
-#### 0.4.5 - Chrome popup window support
+## License
 
-...and more improvements coming soon!
+Licensed under the Apache License 2.0. See [LICENSE](LICENSE).

--- a/package.json
+++ b/package.json
@@ -4,18 +4,19 @@
   "description": "Vacabulary Assistant helps you effortlessly build and organize your vocabulary while browsing the web.",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "typecheck": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Reckue/terms-plugin.git"
+    "url": "git+https://github.com/Reckue/reckue-langs.git"
   },
   "author": "Hardelele",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Reckue/terms-plugin/issues"
+    "url": "https://github.com/Reckue/reckue-langs/issues"
   },
-  "homepage": "https://github.com/Reckue/terms-plugin#readme",
+  "homepage": "https://github.com/Reckue/reckue-langs#readme",
   "devDependencies": {
     "@types/chrome": "^0.1.43",
     "ts-loader": "^9.6.1",


### PR DESCRIPTION
Переписан README и заведена базовая opensource-инфраструктура.

## README
- Убраны эмодзи и маркетинговый тон, исправлены опечатки (Extension, Vocabulary)
- Build-гайд приведён к реальности: бандлы `dist/page/page.js`, `dist/popup/popup.js`
- Бейдж лицензии → Apache-2.0

## Opensource
- `LICENSE` — Apache License 2.0
- `CONTRIBUTING.md` — setup, конвенции веток/коммитов/версий, PR-флоу
- `.github/workflows/ci.yml` — CI на PR/push: `npm ci` → typecheck → build (Node 20)
- Шаблоны issue (bug/feature) и PR

## package.json
- `license` ISC → Apache-2.0 (был конфликт с бейджем)
- URL'ы repository/bugs/homepage → фактический `Reckue/reckue-langs`
- Добавлен скрипт `typecheck` (`tsc --noEmit`)

Изменение `manifest.json` (`unlimitedStorage`) в этот PR не входит.
