### PR TITLE
Add Chrome Web Store badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ npm run build    # build the extension bundles into dist/
 npm run typecheck # type-check without emitting
 ```
 
-Load the unpacked extension from the project root (the folder with `manifest.json`) via `chrome://extensions/` → **Developer mode** → **Load unpacked**. See the [README](README.md#build--install-development) for the full walkthrough.
+Load the unpacked extension from the project root (the folder with `manifest.json`) via `chrome://extensions/` → **Developer mode** → **Load unpacked**. See the [README](README.md#build--run-from-source-development) for the full walkthrough.
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > An interactive vocabulary builder for Chrome â€” click words on any page to save, highlight, and turn them into flashcards.
 
+<a href="https://chromewebstore.google.com/detail/reckue-languages/lebjogkihmfhiojkmnbadppoebfkhfcg">
+  <img src="https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/UV4C4ybeBTsZt43U4xis.png" alt="Available in the Chrome Web Store" height="58">
+</a>
+
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/github/package-json/v/Reckue/reckue-langs)](https://github.com/Reckue/reckue-langs)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -22,7 +26,11 @@ Saved words stay highlighted across pages, so you keep seeing them in context â€
 
 ![Extension in action](img_2.png)
 
-## Build & install (development)
+## Install
+
+Get the published extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/reckue-languages/lebjogkihmfhiojkmnbadppoebfkhfcg).
+
+## Build & run from source (development)
 
 The extension is built from TypeScript with Webpack. To run it locally as an unpacked extension:
 


### PR DESCRIPTION
Добавлен официальный бейдж «Available in the Chrome Web Store» под tagline и ссылка на стор в новую секцию **Install**.

- Бейдж ведёт на листинг: https://chromewebstore.google.com/detail/reckue-languages/lebjogkihmfhiojkmnbadppoebfkhfcg
- Прежняя секция переименована в **Build & run from source (development)**; ссылка-якорь в `CONTRIBUTING.md` обновлена под новый заголовок.
