### PR TITLE
Knowledge-unit model layer (scaffolding)

### DIFF
--- a/src/core/words/KnowledgeResolver.ts
+++ b/src/core/words/KnowledgeResolver.ts
@@ -1,0 +1,70 @@
+import {KnowledgeUnit, RelationProviders, UnitMember} from "./KnowledgeUnit";
+
+/**
+ * Собирает единицы знания над плоским словарём (word→level) по провайдерам связей.
+ * Источник истины — словарь; юниты вычисляются и не хранятся.
+ *
+ * Сейчас провайдеры семей/конструкций возвращают пусто → каждое сохранённое слово
+ * становится юнитом-одиночкой (голова = слово). Когда подключим word_derivations,
+ * та же логика начнёт подвешивать членов семьи под лемму без изменений потребителей.
+ */
+export class KnowledgeResolver {
+
+    constructor(private readonly providers: RelationProviders) {
+    }
+
+    /** Все единицы знания из словаря (для попапа-словаря). */
+    units(cache: Map<string, string>): KnowledgeUnit[] {
+        const claimed = new Set<string>();
+        const units: KnowledgeUnit[] = [];
+
+        cache.forEach((_level, word) => {
+            if (claimed.has(word)) {
+                return;
+            }
+            const unit = this.build(word, cache, claimed);
+            units.push(unit);
+        });
+
+        return units;
+    }
+
+    /** Единица знания для конкретного слова (для клик-попапа над словом). */
+    unitFor(word: string, cache: Map<string, string>): KnowledgeUnit {
+        const lemma = this.providers.lemmaOf(word) ?? word;
+        return this.build(lemma, cache, new Set<string>());
+    }
+
+    /** Строит юнит с головой-леммой, подвешивая сохранённые семью и конструкции. */
+    private build(lemma: string, cache: Map<string, string>, claimed: Set<string>): KnowledgeUnit {
+        claimed.add(lemma);
+        const members = this.savedMembers(this.providers.familyOf(lemma), lemma, cache, claimed, "derivation");
+        const constructions = this.savedMembers(this.providers.constructionsOf(lemma), lemma, cache, claimed, "construction");
+        return {
+            lemma,
+            level: cache.get(lemma),
+            members,
+            constructions
+        };
+    }
+
+    /** Из списка кандидатов оставляет только сохранённые (и ещё не занятые) слова. */
+    private savedMembers(
+        candidates: string[],
+        head: string,
+        cache: Map<string, string>,
+        claimed: Set<string>,
+        relation: UnitMember["relation"]
+    ): UnitMember[] {
+        const members: UnitMember[] = [];
+        for (const word of candidates) {
+            const level = cache.get(word);
+            if (word === head || level === undefined || claimed.has(word)) {
+                continue;
+            }
+            claimed.add(word);
+            members.push({word, level, relation});
+        }
+        return members;
+    }
+}

--- a/src/core/words/KnowledgeUnit.ts
+++ b/src/core/words/KnowledgeUnit.ts
@@ -1,0 +1,42 @@
+/** Как сохранённое слово относится к голове своей единицы знания. */
+export type Relation = "lemma" | "derivation" | "construction";
+
+export interface UnitMember {
+    word: string;
+    level: string;          // имя уровня (см. core/enum/Levels)
+    relation: Relation;
+}
+
+/**
+ * Единица знания — группировка над плоским словарём (word→level). Голова — лемма
+ * (инфинитив); под ней сохранённые члены семьи (деривации) и связанные
+ * конструкции. В storage НЕ хранится: вычисляется [[KnowledgeResolver]] из словаря
+ * + провайдеров связей. Источник истины остаётся плоским словарём.
+ */
+export interface KnowledgeUnit {
+    lemma: string;
+    level?: string;                 // уровень самой леммы, если она сохранена
+    members: UnitMember[];          // деривации: decision, decisive, indecisive
+    constructions: UnitMember[];    // многословные: look forward to, decide on
+}
+
+/**
+ * Источники связей. Инжектятся, чтобы ядро не зависело от контент-скрипта:
+ * `lemmaOf` приходит из словаря инфлексий (page/word/LemmaDictionary), а
+ * `familyOf`/`constructionsOf` подключатся позже с данными word_derivations.
+ */
+export interface RelationProviders {
+    /** Лемма (инфинитив) для словоформы; undefined, если это не инфлексия. */
+    lemmaOf: (word: string) => string | undefined;
+    /** Леммы-члены семьи (деривации) для данной леммы. */
+    familyOf: (lemma: string) => string[];
+    /** Связанные конструкции (многословные) для леммы. */
+    constructionsOf: (lemma: string) => string[];
+}
+
+/** Заглушка без связей: каждое слово — юнит-одиночка (пока нет данных семей). */
+export const NO_RELATIONS: RelationProviders = {
+    lemmaOf: () => undefined,
+    familyOf: () => [],
+    constructionsOf: () => []
+};


### PR DESCRIPTION
**Рост модели Map→KnowledgeUnit** (фундамент под семьи + новый попап).

## Что
- `core/words/KnowledgeUnit.ts` — типы: `KnowledgeUnit` (голова-лемма + члены семьи + конструкции), `UnitMember`, `RelationProviders` (инжектируемые `lemmaOf`/`familyOf`/`constructionsOf`).
- `core/words/KnowledgeResolver.ts` — собирает юниты из плоского словаря + провайдеров; `units()` (для списка) и `unitFor(word)` (для клик-попапа).

## Решение по форме
- **Storage остаётся плоским** `word→level` — члены семьи это отдельные ключи, конструкции — многословные ключи; юзер авторствует только уровни.
- **Юнит вычисляется, не хранится.** Провайдеры инжектятся → ядро не зависит от контент-скрипта.
- Без данных семей каждый юнит — одиночка; та же логика начнёт строить дерево, как только подключим `word_derivations`, без правок потребителей.

## Статус
Каркас: потребителя/проводки пока нет, бандл не меняется. typecheck+build зелёные.

## Дальше плагается
- `FamilyProvider` из `word_derivations` (нужна ручка Langs + проверка/наполнение данных на проде).
- Потребление: новый Popup-UI по мокапу (`unitFor`) и попап-словарь (`units`).